### PR TITLE
Automatically update the README with a table of all RFCs/ADRs

### DIFF
--- a/.github/workflows/update-toc.yaml
+++ b/.github/workflows/update-toc.yaml
@@ -1,0 +1,33 @@
+name: update toc
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  update-toc:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Update README
+        run: ./hack/update-toc.sh
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: |
+            Update TOC
+          committer: GitHub <noreply@github.com>
+          author: weaveworks-admin-bot <41998074+weaveworks-admin-bot@users.noreply.github.com>
+          branch: update-toc
+          title: Update TOC
+      - name: Check output
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # weave-gitops-private
 This is for tracking weaveworks internal information on weave-gitops. Will include issues, internal roadmaps, etc.
+
+## Architecture Decision Records
+
+<!-- ADRS -->
+<!-- /ADRS -->
+
+## Requests For Comments
+
+<!-- RFCS -->
+<!-- /RFCS -->

--- a/hack/update-toc.sh
+++ b/hack/update-toc.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+BASEDIR=$(dirname "${BASH_SOURCE[0]}")
+RFC_DIR=${RFC_DIR:-${BASEDIR}/../docs/rfcs}
+ADR_DIR=${ADR_DIR:-${BASEDIR}/../docs/adrs}
+
+function update-toc() {
+    MARKER=$1
+    DIR=$2
+    PATTERN=$3
+    FILE=$4
+    RELDIR=$5
+
+    CONTENT="<!-- $MARKER -->\n\n"
+
+    for match in "${DIR}"/${PATTERN} ; do
+        TITLE=$(grep '^# ' "${match}${FILE}" | head -1)
+        TITLE=${TITLE### }
+        TITLE=${TITLE%% }
+        CONTENT="${CONTENT}- [${TITLE}](${RELDIR}/$(basename "${match}"))\n"
+    done
+
+    CONTENT="${CONTENT}\n<!-- /${MARKER} -->"
+
+    sed -i '/^<!-- '"${MARKER}"' -->$/,/^<!-- \/'"${MARKER}"' -->$/c'\\"${CONTENT}" "${BASEDIR}"/../README.md
+}
+
+update-toc "RFCS" "${RFC_DIR}" "*/" "/README.md" "docs/rfcs"
+update-toc "ADRS" "${ADR_DIR}" "*.md" "" "docs/adrs"


### PR DESCRIPTION
This PR adds a script that updates the repo root's README.md file with a table of contents of all ADRs and RFCs it finds in the repo.

A GitHub Actions workflow accompanying the script is added that runs the script and creates a PR to update the README. The workflow is run on each merge to main but will only create a PR if any changes to the README are actually applied.