### PR TITLE
create RFC 0004 for fluent-bit

### DIFF
--- a/docs/rfcs/0004-log-forwarder-for-gitops-run/README.md
+++ b/docs/rfcs/0004-log-forwarder-for-gitops-run/README.md
@@ -18,7 +18,7 @@ The integration of Fluent-Bit into GitOps Run will provide users with the abilit
 
 - Install and configure Fluent-Bit to collect logs from all pods in the VCluster.
 - Set up the built-in S3-compatible bucket (the dev-bucket server) to store the collected logs & configure the bucket credentials for Fluent-Bit to allow it to access the bucket.
-- Consider the storage type and log retention policy for the S3-compatible bucket.
+- Consider the storage type (in-memory vs disk-based) and log retention policy (currently there is no retention policy in place) for the S3-compatible bucket.
 - Write an API that allows users to retrieve logs by pod name and namespace.
 - Document the system and API for other users and maintainers.
 
@@ -138,7 +138,7 @@ The integration of Fluent-Bit into GitOps Run should not have any compatibility 
 
 ## Implementation
 
-The implementation of this feature will involve installing and configuring Fluent-Bit as part of the GitOps Run command, configuring credentials for Fluent-Bit to access the dev-bucket server, considering the storage type and log retention policy for the dev-bucket, writing an API for log retrieval, and creating documentation. These tasks should be assigned to a development team, with appropriate testing and documentation being performed at each step.
+The implementation of this feature will involve installing and configuring Fluent-Bit as part of the GitOps Run command, configuring credentials for Fluent-Bit to access the dev-bucket server, considering the storage type (in-memory or disk-based)and log retention policy (currently there is no retention policy in place) for the dev-bucket, writing an API for log retrieval, and creating documentation. These tasks should be assigned to a development team, with appropriate testing and documentation being performed at each step.
 
 ## Open issues (if applicable)
 - Further discussion is needed on the storage type and log retention policy for the dev-bucket.


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops/issues/3195

This RFC proposes the integration of Fluent-Bit into Weave GitOps as a log forwarder to collect logs from all pods in a VCluster. Fluent-Bit is written in C/C++ and is lightweight compared to FluentD, which is written in Ruby. 

It will be installed using Helm and configured to read logs from all containers in the /var/log/containers/ directory, apply the kubernetes filter to merge and exclude relevant log lines, and output the logs to an S3 bucket. An API will also be created to allow users to retrieve logs by pod name and namespace. The storage type and log retention policy for the S3 bucket will be considered, and appropriate documentation will be created for other users and maintainers.